### PR TITLE
fix: update SOP examples for error code signature

### DIFF
--- a/skill/references/implementation-specialist-sop.md
+++ b/skill/references/implementation-specialist-sop.md
@@ -165,9 +165,10 @@ git commit -m "feat(<module>): <description>"
 // ❌ WRONG - Cannot extend native Error class
 export class MyError extends Error { }
 
-// ✅ CORRECT - Use existing CDK error types (1st arg is an error code)
+// ✅ CORRECT - Use existing CDK error types (1st arg is an error code via `lit` tag)
 import { UnscopedValidationError } from '../../core';
-throw new UnscopedValidationError('InvalidPropValue', 'Clear error message with suggested fix');
+import { lit } from '../../core/lib/private/literal-string';
+throw new UnscopedValidationError(lit`InvalidPropValue`, 'Clear error message with suggested fix');
 
 // ✅ CORRECT - For construct-specific errors
 import { ConstructError } from '../../core';
@@ -180,7 +181,7 @@ export class MyError extends ConstructError { }
 // Always provide actionable error messages
 if (!isValidInput(input)) {
   throw new UnscopedValidationError(
-    'InvalidInput',
+    lit`InvalidInput`,
     `Invalid input '${input}'. ${getValidationSuggestion(input)}`
   );
 }
@@ -193,7 +194,7 @@ if (!isValidInput(input)) {
 private validateProps(props: MyConstructProps): void {
   if (props.value < 0) {
     throw new UnscopedValidationError(
-      'NegativeValue',
+      lit`NegativeValue`,
       `'value' must be non-negative, got ${props.value}`
     );
   }

--- a/skill/references/implementation-specialist-sop.md
+++ b/skill/references/implementation-specialist-sop.md
@@ -165,9 +165,9 @@ git commit -m "feat(<module>): <description>"
 // ❌ WRONG - Cannot extend native Error class
 export class MyError extends Error { }
 
-// ✅ CORRECT - Use existing CDK error types
+// ✅ CORRECT - Use existing CDK error types (1st arg is an error code)
 import { UnscopedValidationError } from '../../core';
-throw new UnscopedValidationError('Clear error message with suggested fix');
+throw new UnscopedValidationError('InvalidPropValue', 'Clear error message with suggested fix');
 
 // ✅ CORRECT - For construct-specific errors
 import { ConstructError } from '../../core';
@@ -180,6 +180,7 @@ export class MyError extends ConstructError { }
 // Always provide actionable error messages
 if (!isValidInput(input)) {
   throw new UnscopedValidationError(
+    'InvalidInput',
     `Invalid input '${input}'. ${getValidationSuggestion(input)}`
   );
 }
@@ -192,6 +193,7 @@ if (!isValidInput(input)) {
 private validateProps(props: MyConstructProps): void {
   if (props.value < 0) {
     throw new UnscopedValidationError(
+      'NegativeValue',
       `'value' must be non-negative, got ${props.value}`
     );
   }

--- a/skill/references/regression-reviewer-sop.md
+++ b/skill/references/regression-reviewer-sop.md
@@ -145,11 +145,13 @@ Read available artifacts:
 - [ ] Error messages provide actionable guidance
 - [ ] Consistent with other validation in the same class
 - [ ] Test coverage for error messages with multiple constructs
+- [ ] Every `ValidationError` / `UnscopedValidationError` has an error code as the 1st argument (PascalCase)
 
 **Red flags:**
 - Using `UnscopedValidationError` in construct validation
 - Error messages without construct path information
 - Generic errors that don't help identify which construct failed
+- Missing error code argument (old 1-arg / 2-arg signature)
 
 #### 7d. Exported Mutable Objects (see Appendix D for details)
 
@@ -258,13 +260,14 @@ import { Token } from 'aws-cdk-lib';
 
 public static connectionStringFromJson(template: string): SecretAttachmentTargetProps {
   if (Token.isUnresolved(template)) {
-    throw new Error('connectionStringFromJson does not support tokenized templates. ' +
+    throw new UnscopedValidationError('TokenizedTemplateNotSupported',
+      'connectionStringFromJson does not support tokenized templates. ' +
       'Template must be a concrete string value at synthesis time.');
   }
   
   // Now safe to validate
   if (template.trim().length === 0) {
-    throw new Error('Template cannot be empty');
+    throw new UnscopedValidationError('EmptyTemplate', 'Template cannot be empty');
   }
   // ...
 }
@@ -312,7 +315,8 @@ public static connectionStringFromJson(template: string): SecretAttachmentTarget
   // Check for CloudFormation pseudo-parameters
   const pseudoParamPattern = /\$\{AWS::[a-zA-Z]+\}/;
   if (pseudoParamPattern.test(template)) {
-    throw new Error(
+    throw new UnscopedValidationError(
+      'PseudoParameterNotSupported',
       'connectionStringFromJson does not support CloudFormation pseudo-parameters ' +
       '(e.g., ${AWS::Region}, ${AWS::AccountId}). ' +
       'Template must only contain secret value placeholders like ${placeholder}. ' +
@@ -395,7 +399,7 @@ import { ValidationError } from './private/validation';
 // Option 1: Instance method
 public addConnectionString(template: string): void {
   if (template.trim().length === 0) {
-    throw new ValidationError('Template cannot be empty', this);
+    throw new ValidationError('EmptyTemplate', 'Template cannot be empty', this);
   }
   // ...
 }
@@ -407,6 +411,7 @@ public static connectionStringFromJson(
 ): SecretAttachmentTargetProps {
   if (template.trim().length === 0) {
     throw new ValidationError(
+      'EmptyTemplate',
       'Template cannot be empty. Provide a JSON template with placeholders like {"host": "${host}"}',
       scope
     );
@@ -419,7 +424,7 @@ public static connectionStringFromJson(template: string): SecretAttachmentTarget
   return {
     bind: (scope: Construct) => {
       if (template.trim().length === 0) {
-        throw new ValidationError('Template cannot be empty', scope);
+        throw new ValidationError('EmptyTemplate', 'Template cannot be empty', scope);
       }
       // ...
     }

--- a/skill/references/regression-reviewer-sop.md
+++ b/skill/references/regression-reviewer-sop.md
@@ -145,13 +145,14 @@ Read available artifacts:
 - [ ] Error messages provide actionable guidance
 - [ ] Consistent with other validation in the same class
 - [ ] Test coverage for error messages with multiple constructs
-- [ ] Every `ValidationError` / `UnscopedValidationError` has an error code as the 1st argument (PascalCase)
+- [ ] Every `ValidationError` / `UnscopedValidationError` has an error code as the 1st argument, passed via the `lit` tagged template literal (PascalCase)
 
 **Red flags:**
 - Using `UnscopedValidationError` in construct validation
 - Error messages without construct path information
 - Generic errors that don't help identify which construct failed
 - Missing error code argument (old 1-arg / 2-arg signature)
+- Error code passed as a plain string instead of `` lit`Code` ``
 
 #### 7d. Exported Mutable Objects (see Appendix D for details)
 
@@ -260,14 +261,14 @@ import { Token } from 'aws-cdk-lib';
 
 public static connectionStringFromJson(template: string): SecretAttachmentTargetProps {
   if (Token.isUnresolved(template)) {
-    throw new UnscopedValidationError('TokenizedTemplateNotSupported',
+    throw new UnscopedValidationError(lit`TokenizedTemplateNotSupported`,
       'connectionStringFromJson does not support tokenized templates. ' +
       'Template must be a concrete string value at synthesis time.');
   }
   
   // Now safe to validate
   if (template.trim().length === 0) {
-    throw new UnscopedValidationError('EmptyTemplate', 'Template cannot be empty');
+    throw new UnscopedValidationError(lit`EmptyTemplate`, 'Template cannot be empty');
   }
   // ...
 }
@@ -316,7 +317,7 @@ public static connectionStringFromJson(template: string): SecretAttachmentTarget
   const pseudoParamPattern = /\$\{AWS::[a-zA-Z]+\}/;
   if (pseudoParamPattern.test(template)) {
     throw new UnscopedValidationError(
-      'PseudoParameterNotSupported',
+      lit`PseudoParameterNotSupported`,
       'connectionStringFromJson does not support CloudFormation pseudo-parameters ' +
       '(e.g., ${AWS::Region}, ${AWS::AccountId}). ' +
       'Template must only contain secret value placeholders like ${placeholder}. ' +
@@ -395,11 +396,12 @@ Generic errors without construct context make debugging difficult when users hav
 
 ```typescript
 import { ValidationError } from './private/validation';
+import { lit } from '../../core/lib/private/literal-string'; // adjust relative path
 
 // Option 1: Instance method
 public addConnectionString(template: string): void {
   if (template.trim().length === 0) {
-    throw new ValidationError('EmptyTemplate', 'Template cannot be empty', this);
+    throw new ValidationError(lit`EmptyTemplate`, 'Template cannot be empty', this);
   }
   // ...
 }
@@ -411,7 +413,7 @@ public static connectionStringFromJson(
 ): SecretAttachmentTargetProps {
   if (template.trim().length === 0) {
     throw new ValidationError(
-      'EmptyTemplate',
+      lit`EmptyTemplate`,
       'Template cannot be empty. Provide a JSON template with placeholders like {"host": "${host}"}',
       scope
     );
@@ -424,7 +426,7 @@ public static connectionStringFromJson(template: string): SecretAttachmentTarget
   return {
     bind: (scope: Construct) => {
       if (template.trim().length === 0) {
-        throw new ValidationError('EmptyTemplate', 'Template cannot be empty', scope);
+        throw new ValidationError(lit`EmptyTemplate`, 'Template cannot be empty', scope);
       }
       // ...
     }


### PR DESCRIPTION
### Problem

SOP code examples use the old `ValidationError` / `UnscopedValidationError` signatures. aws/aws-cdk#36934 made the error code a required 1st argument, and per [AGENTS.md](https://github.com/aws/aws-cdk/blob/main/AGENTS.md#error-handling) in aws-cdk the code must be passed via the `lit` tagged template literal (enforced by the `LiteralString` branded type and a runtime check).

### Changes

| File | Change |
|------|--------|
| `skill/references/implementation-specialist-sop.md` | Update 3 code examples to pass the error code via `` lit`Code` ``; add `lit` import |
| `skill/references/regression-reviewer-sop.md` | Update Appendix A/B/C examples to use `` lit`Code` ``; add `lit` import; add error-code + `lit` items to the section 7c checklist |