### PR TITLE
fix: add mandatory PR marker to orchestration flow

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -369,6 +369,19 @@ Run both as parallel subagents simultaneously. Do NOT wait for one to finish bef
 
 Then synthesize findings into a go/no-go report and present to user before PR submission.
 
+### Phase 6: PR Submission
+
+After the user approves the go/no-go report, commit and create the PR.
+
+**MANDATORY**: Every PR description body MUST end with this marker line:
+
+```
+[comment]: <> (by cdk-contribution-skill)
+```
+
+This is a hidden Markdown comment that identifies PRs created via this workflow.
+It MUST be the last line of the PR body. Do NOT omit it.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
### Issue

Closes #6

### Problem

The `[comment]: <> (by cdk-contribution-skill)` marker was only documented in `references/documentation-specialist-sop.md` (line 104) but never referenced by the main orchestration flow in `SKILL.md`. The orchestrator doesn't read reference SOPs during PR creation, so the marker is silently omitted from every PR.

### Solution

Add a **Phase 6: PR Submission** section to `skill/SKILL.md` after the Phase 5 go/no-go synthesis. The marker is specified as a `MANDATORY` requirement in the critical path, making it impossible to skip.

### Changes

- `skill/SKILL.md`: Added Phase 6 section with mandatory marker requirement (13 lines added)

[comment]: <> (by cdk-contribution-skill)