### PR TITLE
fix: use the reference SOP files and make deliverable files consistent

### DIFF
--- a/cdk-contribution-skill/SKILL.md
+++ b/cdk-contribution-skill/SKILL.md
@@ -162,7 +162,7 @@ Do NOT invoke them in parallel. Do NOT put them in the same subagent call.
 
 **Step A — Invoke Phase 1 subagent:**
 
-> Analyze the GitHub issue at <ISSUE_URL>.
+> Analyze the GitHub issue at <ISSUE_URL>. Follow the instructions in `references/issue-analyst-sop.md`.
 >
 > To fetch issue data, use the following priority order:
 >
@@ -282,11 +282,11 @@ Here's what I'm about to do:
 Kicking off now...
 ```
 
-Then proceed immediately without waiting for a response.
+Then proceed immediately without waiting for a response. Follow the instructions in `references/build-engineer-sop.md` for the build phase.
 
 Steps (in order, no skipping):
 
-1. Create a local PR branch named `fix/issue-<NUMBER>-<short-slug>` from current HEAD
+1. Create a local PR branch named `fix/issue-<NUMBER>-<short-description>` from current HEAD
 2. Sync with upstream main:
    - `git fetch upstream`
    - `git rebase upstream/main`
@@ -297,7 +297,7 @@ Steps (in order, no skipping):
    - If changes are purely in `.ts` source + tests with no codegen dependency, skip the build
      and go straight to implementation
    - Document the decision in `03-build.md`
-4. Implement all changes from the approved plan in `02-solution.md`
+4. Implement all changes from the approved plan in `02-solution.md`. Follow the instructions in `references/implementation-specialist-sop.md`.
 5. Write deliverable to `.kiro/contributions/<ISSUE_NUMBER>/03-build.md` (with ASCII diagram)
 
 ### Phase 4: Parallel Validation
@@ -333,14 +333,16 @@ Then proceed immediately without waiting for a response.
 
 Run all three as parallel subagents simultaneously. Do NOT wait for one to finish before starting the next.
 
-- TEST subagent:
+- TEST subagent: Follow the instructions in `references/test-engineer-sop.md`.
   - Run unit tests for all affected packages
   - Integ tests:
     1. Check if new or updated integ test files exist (compare against `02-solution.md` plan)
     2. If YES — run `yarn integ-runner --update-on-failed` on those files to deploy and regenerate snapshots
     3. If NO  — run `yarn integ-runner --update-on-failed` on the relevant module to confirm existing snapshots are intact and unchanged
-- QA checks (lint, build)
-- Documentation updates
+- QA checks (lint, build): Follow the instructions in `references/quality-assurance-sop.md`.
+- Documentation updates: Follow the instructions in `references/documentation-specialist-sop.md`.
+
+When all three subagents have succeeded, summarize the testing, QA and documentation update details in `.kiro/contributions/<ISSUE_NUMBER>/04-validation.md`.
 
 ### Phase 5: Self Review
 
@@ -377,8 +379,10 @@ Kicking off now...
 Then proceed immediately without waiting for a response.
 
 Run both as parallel subagents simultaneously. Do NOT wait for one to finish before starting the next.
+Follow the instructions in `references/security-reviewer-sop.md` for the security review.
+Follow the instructions in `references/regression-reviewer-sop.md` for the regression review.
 
-Then synthesize findings into a go/no-go report and present to user before PR submission.
+Then follow the instructions in `references/review-report-generator-sop.md` to synthesize findings into a go/no-go report and present to user before PR submission.
 
 ### Phase 6: PR Submission
 
@@ -402,9 +406,21 @@ It MUST be the last line of the PR body. Do NOT omit it.
 - `gh` CLI (preferred for issue analysis) — `gh auth login` must be completed
 - GitHub MCP server (fallback if `gh` CLI is unavailable)
 
-## Reference Files
+## Reference SOPs
 
-Detailed SOPs available in `references/`:
-- Issue analysis, solution architecture, build, implementation
-- Testing, QA, documentation, security review, regression review
-- Supplementary skills: debug-ci, integ-testing, linting
+Detailed standard operating procedures are in `references/`:
+
+| SOP | Phase | Purpose |
+|-----|-------|---------|
+| `issue-analyst-sop.md` | 1 – Analysis | Issue analysis and classification |
+| `solution-architect-sop.md` | 2 – Planning | Solution design and planning |
+| `build-engineer-sop.md` | 3 – Build & Impl | Build environment setup |
+| `implementation-specialist-sop.md` | 3 – Build & Impl | Code implementation |
+| `test-engineer-sop.md` | 4 – Validation | Unit and integration testing |
+| `quality-assurance-sop.md` | 4 – Validation | Lint, build, and quality checks |
+| `documentation-specialist-sop.md` | 4 – Validation | README and docs updates |
+| `security-reviewer-sop.md` | 5 – Self Review | Security review |
+| `regression-reviewer-sop.md` | 5 – Self Review | Regression review |
+| `review-report-generator-sop.md` | 5 – Self Review | Final review report synthesis |
+
+Supplementary references: `debug-ci.md`, `integ-testing.md`, `linting.md`

--- a/cdk-contribution-skill/SKILL.md
+++ b/cdk-contribution-skill/SKILL.md
@@ -112,19 +112,44 @@ STOP and wait for user response. Do NOT proceed until the user confirms.
 
 ---
 
+## Reference Files
+
+**CRITICAL**: The reference files in the `references/` folder define the exact structure and content
+of each deliverable per phase. You MUST read the relevant reference file BEFORE executing each phase:
+
+| SOP | Phase | Purpose |
+|-----|-------|---------|
+| `issue-analyst-sop.md` | 1 – Analysis | Issue analysis and classification |
+| `solution-architect-sop.md` | 2 – Planning | Solution design and planning |
+| `build-engineer-sop.md` | 3 – Build & Impl | Build environment setup |
+| `implementation-specialist-sop.md` | 3 – Build & Impl | Code implementation |
+| `test-engineer-sop.md` | 4 – Validation | Unit and integration testing |
+| `quality-assurance-sop.md` | 4 – Validation | Lint, build, and quality checks |
+| `documentation-specialist-sop.md` | 4 – Validation | README and docs updates |
+| `security-reviewer-sop.md` | 5 – Self Review | Security review |
+| `regression-reviewer-sop.md` | 5 – Self Review | Regression review |
+| `review-report-generator-sop.md` | 5 – Self Review | Final review report synthesis |
+
+Supplementary references: `debug-ci.md`, `integ-testing.md`
+
 ## Deliverables
 
-Each phase MUST write its output to a markdown file under `.kiro/contributions/<ISSUE_NUMBER>/`:
+Each phase MUST write its output to markdown files under `.kiro/contributions/<ISSUE_NUMBER>/`:
 
-| Phase   | Output file                                           |
-|---------|-------------------------------------------------------|
-| Phase 1 | `.kiro/contributions/<ISSUE_NUMBER>/01-analysis.md`   |
-| Phase 2 | `.kiro/contributions/<ISSUE_NUMBER>/02-solution.md`   |
-| Phase 3 | `.kiro/contributions/<ISSUE_NUMBER>/03-build.md`      |
-| Phase 4 | `.kiro/contributions/<ISSUE_NUMBER>/04-validation.md` |
-| Phase 5 | `.kiro/contributions/<ISSUE_NUMBER>/05-review.md`     |
+| Phase   | Output file                                                    |
+|---------|----------------------------------------------------------------|
+| Phase 1 | `.kiro/contributions/<ISSUE_NUMBER>/01-analysis.md`            |
+| Phase 2 | `.kiro/contributions/<ISSUE_NUMBER>/02-solution.md`            |
+| Phase 3 | `.kiro/contributions/<ISSUE_NUMBER>/03-build.md`               |
+| Phase 4 | `.kiro/contributions/<ISSUE_NUMBER>/test-results.md`           |
+| Phase 4 | `.kiro/contributions/<ISSUE_NUMBER>/quality-validation.md`     |
+| Phase 4 | `.kiro/contributions/<ISSUE_NUMBER>/pr.md`                     |
+| Phase 4 | `.kiro/contributions/<ISSUE_NUMBER>/04-validation.md`          |
+| Phase 5 | `.kiro/contributions/<ISSUE_NUMBER>/security-review.md`        |
+| Phase 5 | `.kiro/contributions/<ISSUE_NUMBER>/regression-review.md`      |
+| Phase 5 | `.kiro/contributions/<ISSUE_NUMBER>/05-review.md`              |
 
-The subagent for each phase is responsible for writing its own deliverable file before returning.
+The subagent for each phase is responsible for writing its own deliverable file(s) before returning.
 The orchestrator reads the file as the handoff input to the next phase.
 
 ### Deliverable ASCII Diagram Requirement
@@ -162,7 +187,10 @@ Do NOT invoke them in parallel. Do NOT put them in the same subagent call.
 
 **Step A — Invoke Phase 1 subagent:**
 
-> Analyze the GitHub issue at <ISSUE_URL>. Follow the instructions in `references/issue-analyst-sop.md`.
+> **MANDATORY PRE-READ: Before executing this phase, you MUST read the instructions in `references/issue-analyst-sop.md`**
+> **Do NOT proceed until you have read the file and understand the required deliverables.**
+>
+> Analyze the GitHub issue at <ISSUE_URL>.
 >
 > To fetch issue data, use the following priority order:
 >
@@ -189,6 +217,9 @@ Read `.kiro/contributions/<ISSUE_NUMBER>/01-analysis.md` to confirm it was writt
 
 Pass the content of `01-analysis.md` as `relevant_context` to the Phase 2 subagent:
 
+> **MANDATORY PRE-READ: Before executing this phase, you MUST read the instructions in `references/solution-architect-sop.md`**
+> **Do NOT proceed until you have read the file and understand the required deliverables.**
+>
 > Using the analysis provided in the context, propose a concrete solution for the CDK
 > contribution. Include: the implementation approach, which files need to change and how,
 > required unit tests (what to test and why), required integ tests (which integ test file,
@@ -266,6 +297,16 @@ Continue with this plan? Yes | No | Something Else
 
 ### Phase 3: Build & Implementation
 
+**STEP 0 — READ SOPs (non-negotiable, do this FIRST):**
+
+You MUST read BOTH of these files before ANY other action in this phase:
+1. `references/build-engineer-sop.md` - provides instructions for the build phase
+2. `references/implementation-specialist-sop.md` - provides instructions for the implementation phase
+
+After reading, confirm you understand the required deliverables and procedures.
+
+**STEP 1**
+
 Before doing anything, present this summary to the user:
 
 ```text
@@ -282,7 +323,7 @@ Here's what I'm about to do:
 Kicking off now...
 ```
 
-Then proceed immediately without waiting for a response. Follow the instructions in `references/build-engineer-sop.md` for the build phase.
+Then proceed immediately without waiting for a response.
 
 Steps (in order, no skipping):
 
@@ -297,10 +338,21 @@ Steps (in order, no skipping):
    - If changes are purely in `.ts` source + tests with no codegen dependency, skip the build
      and go straight to implementation
    - Document the decision in `03-build.md`
-4. Implement all changes from the approved plan in `02-solution.md`. Follow the instructions in `references/implementation-specialist-sop.md`.
+4. Implement all changes from the approved plan in `02-solution.md`.
 5. Write deliverable to `.kiro/contributions/<ISSUE_NUMBER>/03-build.md` (with ASCII diagram)
 
 ### Phase 4: Parallel Validation
+
+**STEP 0 — READ SOPs (non-negotiable, do this FIRST):**
+
+You MUST read ALL THREE of these files before ANY other action in this phase:
+1. `references/test-engineer-sop.md` - provides instructions for the testing subagent. Required deliverable: `test-results.md`.
+2. `references/quality-assurance-sop.md` - provides instructions for the QA subagent. Required deliverable: `quality-validation.md`
+3. `references/documentation-specialist-sop.md` - provides instructions for the documentation subagent. Required deliverable: `pr.md`
+
+After reading, confirm you understand the required deliverables and procedures.
+
+**STEP 1**
 
 Before doing anything, present this summary to the user:
 
@@ -333,18 +385,29 @@ Then proceed immediately without waiting for a response.
 
 Run all three as parallel subagents simultaneously. Do NOT wait for one to finish before starting the next.
 
-- TEST subagent: Follow the instructions in `references/test-engineer-sop.md`.
+- TEST subagent:
   - Run unit tests for all affected packages
   - Integ tests:
     1. Check if new or updated integ test files exist (compare against `02-solution.md` plan)
     2. If YES — run `yarn integ-runner --update-on-failed` on those files to deploy and regenerate snapshots
     3. If NO  — run `yarn integ-runner --update-on-failed` on the relevant module to confirm existing snapshots are intact and unchanged
-- QA checks (lint, build): Follow the instructions in `references/quality-assurance-sop.md`.
-- Documentation updates: Follow the instructions in `references/documentation-specialist-sop.md`.
+- QA checks (lint, build)
+- Documentation updates
 
-When all three subagents have succeeded, summarize the testing, QA and documentation update details in `.kiro/contributions/<ISSUE_NUMBER>/04-validation.md`.
+When all three subagents have succeeded, summarize the testing, QA and documentation details in `.kiro/contributions/<ISSUE_NUMBER>/04-validation.md`.
 
 ### Phase 5: Self Review
+
+**STEP 0 — READ SOPs (non-negotiable, do this FIRST):**
+
+You MUST read ALL THREE of these files before ANY other action in this phase:
+1. `references/security-reviewer-sop.md` - provides instructions for the security review subagent. Required deliverable: `security-review.md`.
+2. `references/regression-reviewer-sop.md` - provides instructions for the regression review subagent. Required deliverable: `regression-review.md`
+3. `references/review-report-generator-sop.md` - provides instructions for creating the final review report. Required deliverable: `05-review.md`
+
+After reading, confirm you understand the required deliverables and procedures.
+
+**STEP 1**
 
 Before doing anything, present this summary to the user:
 
@@ -379,10 +442,8 @@ Kicking off now...
 Then proceed immediately without waiting for a response.
 
 Run both as parallel subagents simultaneously. Do NOT wait for one to finish before starting the next.
-Follow the instructions in `references/security-reviewer-sop.md` for the security review.
-Follow the instructions in `references/regression-reviewer-sop.md` for the regression review.
 
-Then follow the instructions in `references/review-report-generator-sop.md` to synthesize findings into a go/no-go report and present to user before PR submission.
+Synthesize findings into a go/no-go report in `.kiro/contributions/<ISSUE_NUMBER>/05-review.md` and present to user before PR submission.
 
 ### Phase 6: PR Submission
 
@@ -405,22 +466,3 @@ It MUST be the last line of the PR body. Do NOT omit it.
 - Node.js v18+, Yarn
 - `gh` CLI (preferred for issue analysis) — `gh auth login` must be completed
 - GitHub MCP server (fallback if `gh` CLI is unavailable)
-
-## Reference SOPs
-
-Detailed standard operating procedures are in `references/`:
-
-| SOP | Phase | Purpose |
-|-----|-------|---------|
-| `issue-analyst-sop.md` | 1 – Analysis | Issue analysis and classification |
-| `solution-architect-sop.md` | 2 – Planning | Solution design and planning |
-| `build-engineer-sop.md` | 3 – Build & Impl | Build environment setup |
-| `implementation-specialist-sop.md` | 3 – Build & Impl | Code implementation |
-| `test-engineer-sop.md` | 4 – Validation | Unit and integration testing |
-| `quality-assurance-sop.md` | 4 – Validation | Lint, build, and quality checks |
-| `documentation-specialist-sop.md` | 4 – Validation | README and docs updates |
-| `security-reviewer-sop.md` | 5 – Self Review | Security review |
-| `regression-reviewer-sop.md` | 5 – Self Review | Regression review |
-| `review-report-generator-sop.md` | 5 – Self Review | Final review report synthesis |
-
-Supplementary references: `debug-ci.md`, `integ-testing.md`, `linting.md`

--- a/cdk-contribution-skill/references/build-engineer-sop.md
+++ b/cdk-contribution-skill/references/build-engineer-sop.md
@@ -39,7 +39,7 @@ git clean -fqdx -e .kiro
 git fetch upstream
 
 # Update local main branch with upstream changes
-git pull upstream main
+git rebase upstream/main
 ```
 
 If upstream remote not set up:
@@ -49,7 +49,7 @@ git remote add upstream https://github.com/aws/aws-cdk.git
 
 ### Step 3: Determine Branch Name
 
-Use standard format: `fix-<issue-number>`
+Use standard format: `fix/issue-<NUMBER>-<short-description>`
 
 Delete existing branch if it conflicts:
 ```bash
@@ -80,7 +80,7 @@ Confirm:
 
 ## Output Deliverable
 
-Create `build-status.md`:
+Create `03-build.md`:
 
 ```markdown
 # Build Environment Status
@@ -163,4 +163,4 @@ git reset --hard upstream/main
 - [ ] All dependencies installed successfully
 - [ ] Core modules built without errors
 - [ ] Environment ready for implementation
-- [ ] `build-status.md` created
+- [ ] `03-build.md` created

--- a/cdk-contribution-skill/references/documentation-specialist-sop.md
+++ b/cdk-contribution-skill/references/documentation-specialist-sop.md
@@ -16,10 +16,9 @@ You are the Documentation Specialist, responsible for creating comprehensive PR 
 ## Input Requirements
 
 Before starting, read available artifacts:
-- `issue-assessment.md` - Issue details and codebase analysis
-- `plan.md` - Implementation plan
-- `build-status.md` - Build environment
-- `implementation-status.md` - Code changes
+- `01-analysis.md` - Issue details and codebase analysis
+- `02-solution.md` - Implementation plan
+- `03-build.md` - Build environment and code changes
 
 ## Procedure
 

--- a/cdk-contribution-skill/references/implementation-specialist-sop.md
+++ b/cdk-contribution-skill/references/implementation-specialist-sop.md
@@ -16,9 +16,9 @@ You are the Implementation Specialist, responsible for writing the actual code c
 ## Input Requirements
 
 Before starting, read:
-- `build-status.md` for environment status
-- `plan.md` for implementation strategy
-- `issue-assessment.md` for patterns to follow
+- `03-build.md` for environment status
+- `02-solution.md` for implementation strategy
+- `01-analysis.md` for patterns to follow
 
 ## Procedure
 
@@ -65,7 +65,7 @@ Before proceeding, evaluate if this PR requires code changes:
 
 ```bash
 # For documentation-only PRs, just create the branch and make changes
-git checkout -b fix/<issue-number>-<brief-description>
+git checkout -b fix/issue-<NUMBER>-<short-description>
 # Make documentation/typo changes
 git add .
 git commit -m "docs(<module>): <description>"
@@ -102,14 +102,14 @@ Before making any code changes:
 
 Make targeted changes based on the plan:
 
-1. Follow the implementation strategy from `plan.md`
+1. Follow the implementation strategy from `02-solution.md`
 2. Monitor watch output for compilation errors
 3. Fix any errors shown by watch before proceeding
 4. Test incrementally
 
 ### Step 3.5: Write Tests ⚠️ MANDATORY
 
-Write all tests as specified in `plan.md`:
+Write all tests as specified in `02-solution.md`:
 
 #### Unit Tests
 ```bash
@@ -234,7 +234,7 @@ const cfnResource = new CfnMyResource(this, 'Resource', {
 
 ## Output Deliverable
 
-Create `implementation-status.md`:
+Add implementation status section to `03-build.md`:
 
 ```markdown
 # Implementation Status Report
@@ -334,4 +334,4 @@ responseTemplates: {
 - [ ] No linting violations introduced
 - [ ] Breaking changes properly handled
 - [ ] yarn watch process terminated
-- [ ] `implementation-status.md` created
+- [ ] Updated `03-build.md` with the implementation status

--- a/cdk-contribution-skill/references/issue-analyst-sop.md
+++ b/cdk-contribution-skill/references/issue-analyst-sop.md
@@ -133,7 +133,7 @@ Based on analysis, decide:
 
 ## Output Deliverable
 
-Create `issue-assessment.md`:
+Create `01-analysis.md`:
 
 ```markdown
 # Issue Assessment Report
@@ -264,4 +264,4 @@ packages/aws-cdk-lib/aws-<service>/
 - [ ] Implementation approach recommended
 - [ ] Potential pitfalls identified
 - [ ] Decision justified with reasoning
-- [ ] `issue-assessment.md` created
+- [ ] `01-analysis.md` created

--- a/cdk-contribution-skill/references/quality-assurance-sop.md
+++ b/cdk-contribution-skill/references/quality-assurance-sop.md
@@ -16,8 +16,8 @@ You are the Quality Assurance Specialist, responsible for final validation and q
 
 Before starting, read:
 - `test-results.md` for testing status (if available from parallel Test Engineer)
-- `plan.md` for success criteria
-- `implementation-status.md` for implementation details
+- `02-solution.md` for success criteria
+- `03-build.md` for implementation details
 
 ## Procedure
 
@@ -49,18 +49,18 @@ yarn build --fix
 
 ### Step 4: Verify Success Criteria
 
-Review the original `plan.md` success criteria and validate each item:
+Review the original `02-solution.md` success criteria and validate each item:
 
 ```markdown
 ## Success Criteria Validation
-- [ ] <criterion 1 from plan.md> - [PASS/FAIL] - <notes>
-- [ ] <criterion 2 from plan.md> - [PASS/FAIL] - <notes>
-- [ ] <criterion 3 from plan.md> - [PASS/FAIL] - <notes>
+- [ ] <criterion 1 from 02-solution.md> - [PASS/FAIL] - <notes>
+- [ ] <criterion 2 from 02-solution.md> - [PASS/FAIL] - <notes>
+- [ ] <criterion 3 from 02-solution.md> - [PASS/FAIL] - <notes>
 ```
 
 ### Step 5: CloudFormation Impact Validation
 
-If plan.md indicated CloudFormation impact:
+If 02-solution.md indicated CloudFormation impact:
 - [ ] Template generation produces expected changes
 - [ ] No unintended template modifications
 - [ ] Backward compatibility maintained (unless breaking change planned)
@@ -191,7 +191,7 @@ Create `quality-validation.md`:
 - [ ] Linting passes with auto-fix
 - [ ] Full build passes
 - [ ] All tests pass
-- [ ] Success criteria from plan.md are met
+- [ ] Success criteria from 02-solution.md are met
 - [ ] No regressions introduced
 - [ ] Standards compliance verified
 - [ ] Quality issues resolved or documented

--- a/cdk-contribution-skill/references/regression-reviewer-sop.md
+++ b/cdk-contribution-skill/references/regression-reviewer-sop.md
@@ -16,9 +16,9 @@ You are the Regression Reviewer, responsible for identifying potential regressio
 ## Input Requirements
 
 Read available artifacts:
-- `issue-assessment.md` - Issue context
-- `plan.md` - Implementation plan (includes Breaking Change Analysis)
-- `implementation-status.md` - Code changes made
+- `01-analysis.md` - Issue context
+- `02-solution.md` - Implementation plan (includes Breaking Change Analysis)
+- `03-build.md` - Code changes made
 - `test-status.md` - Testing results
 - `pr.md` - PR documentation
 

--- a/cdk-contribution-skill/references/review-report-generator-sop.md
+++ b/cdk-contribution-skill/references/review-report-generator-sop.md
@@ -19,8 +19,8 @@ Before starting, read:
 - `security-review.md` - Security review findings
 - `regression-review.md` - Regression review findings
 - `pr.md` - PR documentation
-- `plan.md` - Implementation plan
-- `implementation-status.md` - Implementation details
+- `02-solution.md` - Implementation plan
+- `03-build.md` - Implementation details
 
 ## Procedure
 
@@ -68,7 +68,7 @@ Determine recommendation:
 
 ## Output Deliverable
 
-Create `review-report.md`:
+Create `05-review.md`:
 
 ```markdown
 # Final Self-Review Report
@@ -354,7 +354,7 @@ Create `review-report.md`:
 
 - **Security Review**: `security-review.md`
 - **Regression Review**: `regression-review.md`
-- **Implementation Plan**: `plan.md`
+- **Implementation Plan**: `02-solution.md`
 - **PR Documentation**: `pr.md`
 
 ---
@@ -451,7 +451,7 @@ LOW + LOW = LOW
 - [ ] Risk assessment completed
 - [ ] Final decision made with clear justification
 - [ ] Next steps clearly outlined
-- [ ] `review-report.md` created
+- [ ] `05-review.md` created
 - [ ] Ready for human decision
 
 ## Critical Reminders

--- a/cdk-contribution-skill/references/security-reviewer-sop.md
+++ b/cdk-contribution-skill/references/security-reviewer-sop.md
@@ -21,9 +21,9 @@ You are the Security Reviewer, responsible for identifying potential security co
 ## Input Requirements
 
 Before starting, you MUST read available artifacts:
-- `issue-assessment.md` - Issue context
-- `plan.md` - Implementation plan
-- `implementation-status.md` - Code changes made
+- `01-analysis.md` - Issue context
+- `02-solution.md` - Implementation plan
+- `03-build.md` - Code changes made
 - `test-status.md` - Testing results
 - `pr.md` - PR documentation
 

--- a/cdk-contribution-skill/references/solution-architect-sop.md
+++ b/cdk-contribution-skill/references/solution-architect-sop.md
@@ -7,7 +7,7 @@ You are the Solution Architect, responsible for creating comprehensive implement
 ## Primary Responsibilities
 
 - **Phase 2**: Implementation Planning (runs after Issue Analyst, before human approval)
-- Create comprehensive implementation plans (plan.md)
+- Create comprehensive implementation plans (02-solution.md)
 - Assess CloudFormation impact, breaking changes, integration test needs
 - Design solution approach following CDK patterns
 - Identify risks and mitigation strategies
@@ -16,7 +16,7 @@ You are the Solution Architect, responsible for creating comprehensive implement
 ## Input Requirements
 
 Before starting, read:
-- `issue-assessment.md` for issue details and codebase analysis
+- `01-analysis.md` for issue details and codebase analysis
 
 ## Procedure
 
@@ -209,7 +209,7 @@ Create specific, measurable success criteria:
 
 ### ⚠️ MANDATORY UPFRONT PRESENTATION — MUST COME FIRST
 
-Before presenting the detailed plan, you MUST lead with these two ASCII diagrams at the very top of `plan.md`:
+Before presenting the detailed plan, you MUST lead with these two ASCII diagrams at the very top of `02-solution.md`:
 
 **1. Current vs Expected Behavior (ASCII)**
 ```
@@ -237,7 +237,7 @@ These two diagrams give the human reviewer immediate clarity on the problem and 
 
 ---
 
-Create `plan.md` with ALL of the following required sections:
+Create `02-solution.md` with ALL of the following required sections:
 
 ⚠️ **REQUIRED SECTIONS** (do not skip any):
 0. Current vs Expected Behavior Diagram ⚠️ MANDATORY — MUST BE FIRST
@@ -573,5 +573,5 @@ Provide an ASCII diagram illustrating the proposed solution:
 - [ ] Implementation strategy is clear and detailed
 - [ ] Risks identified and mitigation planned
 - [ ] Success criteria are specific and measurable
-- [ ] `plan.md` created with approval prompt
+- [ ] `02-solution.md` created with approval prompt
 - [ ] Human approval obtained before proceeding

--- a/cdk-contribution-skill/references/test-engineer-sop.md
+++ b/cdk-contribution-skill/references/test-engineer-sop.md
@@ -16,54 +16,8 @@ You are the Test Engineer, responsible for executing tests written by the Implem
 ## Input Requirements
 
 Before starting, read:
-- `implementation-status.md` for code changes and tests written
-- `plan.md` for testing requirements
-
-## Default Testing Strategy ⚠️ MANDATORY
-
-The Test Engineer executes tests and provides feedback in a 2-phase approach:
-
-### Phase 0: Start Incremental Compilation ⚠️ CRITICAL
-
-```bash
-# Start yarn watch for incremental compilation
-cd packages/aws-cdk-lib
-yarn watch
-```
-
-Benefits:
-- Automatic incremental compilation on file changes
-- No manual yarn build needed between test runs
-- Faster feedback loop during development
-
-### Phase 1: Execute Module Unit Tests ⚠️ MANDATORY
-
-```bash
-# Run unit tests for the specific module
-cd packages/aws-cdk-lib
-yarn test aws-<service>
-```
-
-This validates:
-- Tests written by Implementation Specialist work correctly
-- Module-specific functionality behaves as expected
-- Module dependencies are intact
-
-### Phase 2: Execute Module Integration Tests ⚠️ MANDATORY
-
-```bash
-# Check integration tests written by Implementation Specialist
-cd packages/@aws-cdk-testing/framework-integ
-ls test/<module_name>/test/integ*.js
-
-# Run integration tests for the module
-yarn integ-runner --directory test/<module_name>/test/ --update-on-failed
-```
-
-This validates:
-- CloudFormation template generation for the module
-- AWS service integration for the module
-- Module-specific deployment scenarios
+- `03-build.md` for code changes and tests written
+- `02-solution.md` for testing requirements
 
 ## Procedure
 
@@ -74,12 +28,22 @@ cd packages/aws-cdk-lib
 yarn watch
 ```
 
+Benefits:
+- Automatic incremental compilation on file changes
+- No manual yarn build needed between test runs
+- Faster feedback loop during development
+
 ### Step 2: Execute Module Unit Tests
 
 ```bash
 cd packages/aws-cdk-lib
 yarn test aws-<service>
 ```
+
+This validates:
+- Tests written by Implementation Specialist work correctly
+- Module-specific functionality behaves as expected
+- Module dependencies are intact
 
 Analyze results:
 - Record all test passes and failures
@@ -97,6 +61,11 @@ ls test/<module_name>/test/integ*.js
 # Run integration tests with snapshot updates
 yarn integ-runner --directory test/<module_name>/test/ --update-on-failed
 ```
+
+This validates:
+- CloudFormation template generation for the module
+- AWS service integration for the module
+- Module-specific deployment scenarios
 
 ### Step 4: Analyze and Report Failures
 


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**
* Provided explicit instructions in SKILL.md to use the reference SOPs in each phase
* Made the deliverable files consistent across SKILL.md and the reference SOPs
* Removed duplicate instructions in `test-engineer-sop.md`

Verified the skill changes end-to-end with an issue in `aws-cdk`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
